### PR TITLE
Move babel config to .babelrc to prevent runtime errors

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+  "presets": [
+    "es2015",
+    "stage-2"
+  ],
+  "plugins": [
+    "transform-flow-strip-types",
+    "add-module-exports"
+  ]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,4 @@ node_modules
 .eslintrc.json
 .flowconfig
 .gitignore
+.babelrc

--- a/package.json
+++ b/package.json
@@ -22,16 +22,6 @@
     "lint": "eslint --ext .js ./",
     "build": "npm run lint && babel src -d lib"
   },
-  "babel": {
-    "presets": [
-      "es2015",
-      "stage-2"
-    ],
-    "plugins": [
-      "transform-flow-strip-types",
-      "add-module-exports"
-    ]
-  },
   "devDependencies": {
     "app-module-path": "^1.0.6",
     "babel-cli": "^6.7.5",


### PR DESCRIPTION
Babel configuration in `package.json` means that any project requiring this library that has babel installed but not the presets or plugins will error on load. Moving this configuration to `.babelrc` and ignoring that file in `.npmignore` means that `npm run build` will still successfully transform the codebase, but won't explode on runtime.